### PR TITLE
feat: Create display current epoch time

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,9 @@
 
 version: 2
 
+env:
+  - PACKAGE_NAME=github.com/135yshr/t2e
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -18,7 +21,6 @@ before:
 builds:
   - id: t2e
     binary: t2e
-    main: ./cmd/t2e
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,10 +29,10 @@ builds:
       - darwin
     ldflags:
       - -s -w
-      - -X main.version={{ .Version }}
-      - -X main.commit={{ .Commit }}
-      - -X main.date={{ .Date }}
-      - -X main.builtBy=goreleaser
+      - -X {{ .Env.PACKAGE_NAME }}/cmd.version={{ .Version }}
+      - -X {{ .Env.PACKAGE_NAME }}/cmd.commit={{ .Commit }}
+      - -X {{ .Env.PACKAGE_NAME }}/cmd.date={{ .Date }}
+      - -X {{ .Env.PACKAGE_NAME }}/cmd.builtBy=goreleaser
     tags:
       - release
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newRootCmd() *cobra.Command {
+	// rootCmd represents the base command when called without any subcommands
+	return &cobra.Command{
+		Use:     "t2e",
+		Version: Version(),
+		Short:   "This program converts the specified time to epoch time.",
+		// Uncomment the following line if your bare application
+		// has an action associated with it:
+		// Run: func(cmd *cobra.Command, args []string) { },
+	}
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,13 +13,10 @@ import (
 
 //nolint:forbidigo,revive // Output the results to the terminal
 func newRootCmd() *cobra.Command {
-	// rootCmd represents the base command when called without any subcommands
 	return &cobra.Command{
 		Use:     "t2e",
 		Version: Version(),
 		Short:   "This program converts the specified time to epoch time.",
-		// Uncomment the following line if your bare application
-		// has an action associated with it:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println(time.Now().Unix())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,14 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
+//nolint:forbidigo,revive // Output the results to the terminal
 func newRootCmd() *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	return &cobra.Command{
@@ -17,7 +20,11 @@ func newRootCmd() *cobra.Command {
 		Short:   "This program converts the specified time to epoch time.",
 		// Uncomment the following line if your bare application
 		// has an action associated with it:
-		// Run: func(cmd *cobra.Command, args []string) { },
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(time.Now().Unix())
+
+			return nil
+		},
 	}
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "fmt"
+
+var (
+	version = "0.0.0-dev"
+	commit  = "none"    //nolint:gochecknoglobals // バージョン管理で使う
+	date    = "unknown" //nolint:gochecknoglobals // バージョン管理で使う
+	builtBy = "go"      //nolint:gochecknoglobals // バージョン管理で使う
+)
+
+const template = `
+========================================
+ __    ______
+|  |_ |__    |.-----.
+|   _||    __||  -__|
+|____||______||_____|
+
+========================================
+  Version: %s
+  Commit: %s
+  Date: %s
+  BuiltBy: %s
+`
+
+// Version returns the version string.
+func Version() string {
+	return fmt.Sprintf(template, version, commit, date, builtBy)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/135yshr/t2e
 
 go 1.23
+
+require github.com/spf13/cobra v1.8.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,10 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package main
+
+import "github.com/135yshr/t2e/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary of Changes

- Added display of current epoch time in `cmd/root.go` to show the current epoch time in the terminal.
- Changed version format
- Changed config by goreleaser to use `PACKAGE_NAME` environment variable in `.goreleaser.yaml` to set the version, commit, date, and builtBy fields in the binary.